### PR TITLE
docs: change to non-relative url

### DIFF
--- a/tesla_http_proxy/README.md
+++ b/tesla_http_proxy/README.md
@@ -5,4 +5,4 @@ This add-on runs the official [Tesla HTTP Proxy](https://github.com/teslamotors/
 ## About
 Runs a temporary Flask web server to handle initial Tesla authorization flow and store the refresh token.  Once that is complete, it quits Flask and runs Tesla's HTTP Proxy code in Go.
 
-Setting this up is fairly complex.  Please read [DOCS.md](./DOCS.md) for details.
+Setting this up is fairly complex.  Please read [DOCS.md](https://github.com/llamafilm/tesla-http-proxy-addon/blob/main/tesla_http_proxy/DOCS.md) for details.


### PR DESCRIPTION
Within HA, the relative link would lead to a blank page.