### PR TITLE
Add note for setting the right configuration on Nginx add-on

### DIFF
--- a/tesla_http_proxy/DOCS.md
+++ b/tesla_http_proxy/DOCS.md
@@ -4,6 +4,8 @@
 
 You must have a domain name (FQDN) with a valid SSL certificate to host your public key on standard port 443.  The vehicle will check this key every time you send a command.  The easiest way to do this is using [Nginx SSL proxy add-on](https://github.com/home-assistant/addons/tree/master/nginx_proxy).  This guide will use `tesla.example.com` as an example.
 
+One thing to note is that if you are using the `Nginx SSL proxy add-on` as it is suggested here, you will need to make sure that in the Configuration section of the Nginx add-on the setting under `Customize` called `active` is set to `true` instead of `false`. By default, it will be set to `false` and that will make it such that Nginx will not import the new server configuration blocks that will be added in a later step.
+
 ## How to use
 
 Configure this addon with your domain name, then hit Start.  It will initialize and then stop itself after a few seconds.  Refresh the page to verify it's stopped, then restart the Nginx addon so it loads the new config. Ignore the error: _Failed to restart add-on_.


### PR DESCRIPTION
I noticed this is not currently mentioned on the docs, and his gave me headaches for a few hours trying to figure out what was wrong with my setup. Eventually I realized that Nginx by default has this set to false, and I only realized it after going inside the nginx container and seeing that the import of additional configuration files was commented out. Adding a note to the docs so other's won't hit the same issue I did.

@llamafilm feel free to reword as you see appropriate, but I do think it is important to call this out in some way or form.