### PR TITLE
[run.sh] Add retry if no IP addr is returned

### DIFF
--- a/tesla_http_proxy/config.yaml
+++ b/tesla_http_proxy/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla HTTP Proxy"
-version: "2.2.3"
+version: "2.2.4"
 slug: "tesla_http_proxy"
 description: "Proxy requests for Tesla Fleet API"
 url: "https://github.com/llamafilm/tesla-http-proxy-addon/tree/main/tesla_http_proxy"

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -74,6 +74,19 @@ else
   generate_keypair
 fi
 
+# verify domain $DOMAIN has an associated IP address, if not loop and retry
+bashio::log.info "Testing $DOMAIN for an associated IP address..."
+while :; do
+  if ! host $DOMAIN; then
+    bashio::log.fatal "$DOMAIN has no associated IP address, add a record in your DNS config."
+    bashio::log.fatal "Sleeping 2 minutes before retry."
+    sleep 2m
+  else
+    bashio::log.info "Found an IP address for $DOMAIN"
+    break
+  fi
+done
+
 # verify public key is accessible with valid TLS cert
 bashio::log.info "Testing public key..."
 if ! curl -sfD - "https://$DOMAIN/.well-known/appspecific/com.tesla.3p.public-key.pem"; then


### PR DESCRIPTION
Hello,

I noticed when I restart my NAS, Tesla integration fails because of the proxy that fails with the `Fix public key` - each time, I need to start over and reconfigure everything.

The DEBUG log don't help to confirm the issue but I think the cause is if HAOS (a VM in my case) gets ready before the DNS services that runs in docker instances, the curl fails for that reason.

Creating this PR to add a retry if no IP address is associated to $DOMAIN - let me know what you think. If you want to merge it as-is, great otherwise... I can manually mod the run.sh script in the instance but to reconfigure everything and try it might take a while. Otherwise perhaps a log if no IP is associated could help others trying to configure their proxy for the first time.