### PR TITLE
[run.sh] Add retry if HTTP status code != 200

### DIFF
--- a/tesla_http_proxy/CHANGELOG.md
+++ b/tesla_http_proxy/CHANGELOG.md
@@ -1,5 +1,17 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 2.2.5
+
+### Changed
+
+- Retry public key check if HTTP status code != 200
+
+## 2.2.4
+
+### Changed
+
+- Retry public key check if no IP address is found for the FQDN
+
 ## 2.2.3
 
 ### Changed

--- a/tesla_http_proxy/config.yaml
+++ b/tesla_http_proxy/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla HTTP Proxy"
-version: "2.2.4"
+version: "2.2.5"
 slug: "tesla_http_proxy"
 description: "Proxy requests for Tesla Fleet API"
 url: "https://github.com/llamafilm/tesla-http-proxy-addon/tree/main/tesla_http_proxy"

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -78,8 +78,8 @@ fi
 bashio::log.info "Testing $DOMAIN for an associated IP address..."
 while :; do
   if ! host $DOMAIN; then
-    bashio::log.fatal "$DOMAIN has no associated IP address, add a record in your DNS config."
-    bashio::log.fatal "Sleeping 2 minutes before retry."
+    bashio::log.error "$DOMAIN has no associated IP address, add a record in your DNS config."
+    bashio::log.error "Sleeping 2 minutes before retry."
     sleep 2m
   else
     bashio::log.info "Found an IP address for $DOMAIN"
@@ -99,9 +99,7 @@ while :; do
     bashio::log.info "The public key is accessible."
     break
   else
-    bashio::log.fatal "HTTP status code $HTTP_STATUS_CODE; Use a search engine to learn about the status code."
-    bashio::log.fatal "If the request keeps failing, adjust your configuration for the request not to fail."
-    bashio::log.fatal "Sleeping 2 minutes before retry."
+    bashio::log.error "HTTP status code $HTTP_STATUS_CODE; Sleeping 2 minutes before retry."
     sleep 2m
   fi
 done

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -89,9 +89,7 @@ done
 
 # verify public key is accessible with valid TLS cert
 bashio::log.info "Testing public key..."
-set +e
-CURL_OUT=$(curl -sfLD - "https://$DOMAIN/.well-known/appspecific/com.tesla.3p.public-key.pem")
-set -e
+CURL_OUT=$(curl -sfD - "https://$DOMAIN/.well-known/appspecific/com.tesla.3p.public-key.pem" || true)
 echo "$CURL_OUT"
 # last HTTP status code (in case of a redirect)
 HTTP_STATUS_CODE=$(echo "$CURL_OUT"|awk '/^HTTP/{print $2}'|tail -1)

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -89,18 +89,21 @@ done
 
 # verify public key is accessible with valid TLS cert
 bashio::log.info "Testing public key..."
+set +e
 CURL_OUT=$(curl -sfLD - "https://$DOMAIN/.well-known/appspecific/com.tesla.3p.public-key.pem")
+set -e
 echo "$CURL_OUT"
-# last HTTP code (in case of a redirect)
+# last HTTP status code (in case of a redirect)
 HTTP_STATUS_CODE=$(echo "$CURL_OUT"|awk '/^HTTP/{print $2}'|tail -1)
 while :; do
   if [ "$HTTP_STATUS_CODE" -ge 200 ] && [ "$HTTP_STATUS_CODE" -le 299 ]; then
     # All good
+    bashio::log.info "The public key is accessible."
     break
   else
-    bashio::log.alert "HTTP status code $HTTP_STATUS_CODE; Use a search engine to learn about the status code."
-    bashio::log.alert "If the request keeps failing, adjust your configuration for the request not to fail."
-    bashio::log.alert "Sleeping 2 minutes before retry."
+    bashio::log.fatal "HTTP status code $HTTP_STATUS_CODE; Use a search engine to learn about the status code."
+    bashio::log.fatal "If the request keeps failing, adjust your configuration for the request not to fail."
+    bashio::log.fatal "Sleeping 2 minutes before retry."
     sleep 2m
   fi
 done

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -96,7 +96,7 @@ echo "$CURL_OUT"
 # last HTTP status code (in case of a redirect)
 HTTP_STATUS_CODE=$(echo "$CURL_OUT"|awk '/^HTTP/{print $2}'|tail -1)
 while :; do
-  if [ "$HTTP_STATUS_CODE" -ge 200 ] && [ "$HTTP_STATUS_CODE" -le 299 ]; then
+  if [ "$HTTP_STATUS_CODE" -ne 200 ]; then
     # All good
     bashio::log.info "The public key is accessible."
     break

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -94,7 +94,7 @@ echo "$CURL_OUT"
 # last HTTP status code (in case of a redirect)
 HTTP_STATUS_CODE=$(echo "$CURL_OUT"|awk '/^HTTP/{print $2}'|tail -1)
 while :; do
-  if [ "$HTTP_STATUS_CODE" -ne 200 ]; then
+  if [ "$HTTP_STATUS_CODE" -eq 200 ]; then
     # All good
     bashio::log.info "The public key is accessible."
     break


### PR DESCRIPTION
Following the add retry if no IP is associated to the DOMAIN, I found another case that can fail.

For example, when using a Cloudflare tunnel until the tunnel is in ready state, the HTTP status code will be 502. Just earlier I faced this issue, my guess is that others could as well.

This PR adds:
1) a retry until a 2xx code is returned
2) add curl option -L to follow a redirect - this is just in case someone has an odd config and doesn't break anything.

Let me know what you think / if need to adjust anything.

Thank you.