### PR TITLE
fix: curl retry with exponential backoff

### DIFF
--- a/tesla_http_proxy/CHANGELOG.md
+++ b/tesla_http_proxy/CHANGELOG.md
@@ -1,16 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
-## 2.2.5
+## 2.2.6
 
 ### Changed
 
-- Retry public key check if HTTP status code != 200
-
-## 2.2.4
-
-### Changed
-
-- Retry public key check if no IP address is found for the FQDN
+- Retry public key check for 1 hour if HTTP request fails
 
 ## 2.2.3
 

--- a/tesla_http_proxy/config.yaml
+++ b/tesla_http_proxy/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla HTTP Proxy"
-version: "2.2.5"
+version: "2.2.6"
 slug: "tesla_http_proxy"
 description: "Proxy requests for Tesla Fleet API"
 url: "https://github.com/llamafilm/tesla-http-proxy-addon/tree/main/tesla_http_proxy"

--- a/tesla_http_proxy/rootfs/app/run.sh
+++ b/tesla_http_proxy/rootfs/app/run.sh
@@ -74,35 +74,12 @@ else
   generate_keypair
 fi
 
-# verify domain $DOMAIN has an associated IP address, if not loop and retry
-bashio::log.info "Testing $DOMAIN for an associated IP address..."
-while :; do
-  if ! host $DOMAIN; then
-    bashio::log.error "$DOMAIN has no associated IP address, add a record in your DNS config."
-    bashio::log.error "Sleeping 2 minutes before retry."
-    sleep 2m
-  else
-    bashio::log.info "Found an IP address for $DOMAIN"
-    break
-  fi
-done
-
 # verify public key is accessible with valid TLS cert
 bashio::log.info "Testing public key..."
-CURL_OUT=$(curl -sfD - "https://$DOMAIN/.well-known/appspecific/com.tesla.3p.public-key.pem" || true)
-echo "$CURL_OUT"
-# last HTTP status code (in case of a redirect)
-HTTP_STATUS_CODE=$(echo "$CURL_OUT"|awk '/^HTTP/{print $2}'|tail -1)
-while :; do
-  if [ "$HTTP_STATUS_CODE" -eq 200 ]; then
-    # All good
-    bashio::log.info "The public key is accessible."
-    break
-  else
-    bashio::log.error "HTTP status code $HTTP_STATUS_CODE; Sleeping 2 minutes before retry."
-    sleep 2m
-  fi
-done
+if ! curl -fD - --no-progress-meter --max-time 5 --connect-timeout 2 --retry 14 --retry-all-errors "https://$DOMAIN/.well-known/appspecific/com.tesla.3p.public-key.pem"; then
+  bashio::log.fatal "Fix public key before proceeding."
+  exit 1
+fi
 
 if [ -z "$CLIENT_ID" ]; then
   bashio::log.notice "Request application access with Tesla, then fill in credentials and restart addon."


### PR DESCRIPTION
Retry public key test if HTTP response fails.  With these options, curl will retry 14 times, with exponential backoff, for a total duration of ~1 hour.  Each attempt will fail if it takes longer than 2 seconds to connect or 5 seconds to receive the key.

Partially fixes #100 and #102.
Reverts #94 and #103.