### PR TITLE
Change auth enpoint with the new URL suggested by Tesla.

### DIFF
--- a/tesla_http_proxy/rootfs/app/const.py
+++ b/tesla_http_proxy/rootfs/app/const.py
@@ -7,9 +7,9 @@ AUDIENCES = {
     'China'                      : 'https://fleet-api.prd.cn.vn.cloud.tesla.cn'
 }
 TESLA_AUTH_ENDPOINTS = {
-    'North America, Asia-Pacific': 'https://auth.tesla.com',
-    'Europe, Middle East, Africa': 'https://auth.tesla.com',
-    'China'                      : 'https://auth.tesla.cn'
+    'North America, Asia-Pacific': 'https://fleet-auth.prd.vn.cloud.tesla.com',
+    'Europe, Middle East, Africa': 'https://fleet-auth.prd.vn.cloud.tesla.com',
+    'China'                      : 'https://fleet-auth.prd.vn.cloud.tesla.com'
 }
 TESLA_AK_ENDPOINTS = {
     'North America, Asia-Pacific': 'https://tesla.com',


### PR DESCRIPTION
After this change, the auth flow changes like in the logs below:

[00:23:05] INFO: Running auth.py
[00:23:05] auth:INFO: Generating Partner Authentication Token
[00:23:05] urllib3.connectionpool:DEBUG: Starting new HTTPS connection (1): **auth.tesla.com:443**
[00:23:06] urllib3.connectionpool:DEBUG: https://auth.tesla.com:443 "POST /oauth2/v3/token HTTP/1.1" 200 799

[01:28:19] INFO: Running auth.py
[01:28:20] auth:INFO: Generating Partner Authentication Token
[01:28:20] urllib3.connectionpool:DEBUG: Starting new HTTPS connection (1): **fleet-auth.prd.vn.cloud.tesla.com:443**
[01:28:22] urllib3.connectionpool:DEBUG: https://fleet-auth.prd.vn.cloud.tesla.com:443 "POST /oauth2/v3/token HTTP/1.1" 200 803
